### PR TITLE
feat(defer-block): add multiple defer examples with advanced features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Angular Signals Examples(Angular signals demos)
+# Angular Signals Examples (Angular signals demos)
 
-This repo is explains to Angular signals and real time examples how to create and update signals, use effects, convert from observable and create computed values.
+This repo explains Angular signals and real-time examples showing how to create and update signals, use effects, convert from observables, create computed values, and demonstrates Angular's new defer block functionality for optimized loading strategies.
 
 View Live at [Netlify App URL](https://angular-signal-examples.netlify.app/)
 
@@ -37,6 +37,15 @@ View Live at [Netlify App URL](https://angular-signal-examples.netlify.app/)
 4. Fetch random user using resource [Resource Example 4](https://angular-signal-examples.netlify.app/resource-api/resource-api-example4)
 5. List public GitHub repositories using rxResource [rxResource Example 5](https://angular-signal-examples.netlify.app/resource-api/resource-api-example5)
 6. Fetch a random joke using httpResource [httpResource Example 6](https://angular-signal-examples.netlify.app/resource-api/resource-api-example6)
+
+## Examples - Defer Block
+Angular's defer blocks provide declarative lazy loading for better performance by deferring the loading of parts of your template until specific conditions are met.
+
+1. Basic Defer on Idle - Loads content when browser becomes idle [Defer Example 1](https://angular-signal-examples.netlify.app/defer-block/defer-example1)
+2. Defer on Interaction - Triggers loading when user interacts with element [Defer Example 2](https://angular-signal-examples.netlify.app/defer-block/defer-example2)
+3. Defer on Viewport - Loads content when it enters the viewport [Defer Example 3](https://angular-signal-examples.netlify.app/defer-block/defer-example3)
+4. Defer with Timer - Loads content after specified time delay [Defer Example 4](https://angular-signal-examples.netlify.app/defer-block/defer-example4)
+5. Advanced Defer - Multiple triggers, conditions, and error handling [Defer Example 5](https://angular-signal-examples.netlify.app/defer-block/defer-example5)
 
 ## Development server
 

--- a/src/app-routings.ts
+++ b/src/app-routings.ts
@@ -19,6 +19,10 @@ export const ROUTES: Route[] = [
     loadChildren: () => import('./app/examples/resource-api/resource-api-routings'),
   },
   {
+    path: 'defer-block',
+    loadChildren: () => import('./app/examples/defer-block/defer-block-routings'),
+  },
+  {
     path: 'table',
     loadComponent: () => import('./app/table/table.component'),
   },

--- a/src/app/examples/defer-block/defer-block-routings.ts
+++ b/src/app/examples/defer-block/defer-block-routings.ts
@@ -1,0 +1,36 @@
+import { Route } from '@angular/router';
+
+const ROUTES: Route[] = [
+  {
+    path: '',
+    pathMatch: 'full',
+    loadComponent: () => import('./defer-block.component'),
+  },
+  {
+    path: 'defer-example1',
+    loadComponent: () =>
+      import('./defer-example1/defer-example1.component'),
+  },
+  {
+    path: 'defer-example2',
+    loadComponent: () =>
+      import('./defer-example2/defer-example2.component'),
+  },
+  {
+    path: 'defer-example3',
+    loadComponent: () =>
+      import('./defer-example3/defer-example3.component'),
+  },
+  {
+    path: 'defer-example4',
+    loadComponent: () =>
+      import('./defer-example4/defer-example4.component'),
+  },
+  {
+    path: 'defer-example5',
+    loadComponent: () =>
+      import('./defer-example5/defer-example5.component'),
+  },
+];
+
+export default ROUTES;

--- a/src/app/examples/defer-block/defer-block.component.html
+++ b/src/app/examples/defer-block/defer-block.component.html
@@ -1,0 +1,23 @@
+<div class="flex flex-col w-full gap-4">
+  <div class="w-full">
+    <h2 class="text-2xl font-bold">Defer Block Examples</h2>
+    <div class="flex flex-wrap gap-4">
+      @for (item of deferBlockExamples(); track item) {
+        <a class="item flex-1 min-w-[300px]" [routerLink]="item.routerLink">
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title>
+                {{ item.title }}
+              </mat-card-title>
+            </mat-card-header>
+            <mat-card-content>
+              <p>
+                {{ item.content }}
+              </p>
+            </mat-card-content>
+          </mat-card>
+        </a>
+      }
+    </div>
+  </div>
+</div>

--- a/src/app/examples/defer-block/defer-block.component.scss
+++ b/src/app/examples/defer-block/defer-block.component.scss
@@ -1,0 +1,52 @@
+:host {
+  display: contents;
+  
+  .item {
+    display: flex;
+    text-decoration: none;
+    box-sizing: border-box;
+    border: 1px solid #c2c2c2;
+    border-radius: 10px;
+    margin: 0;
+    overflow: hidden;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    }
+  }
+  
+  .mat-mdc-card.mdc-card {
+    width: 100%;
+    box-shadow: none;
+    height: 100%;
+  }
+  
+  .mat-mdc-card-header {
+    padding: 10px 16px;
+    border-bottom: 1px solid #c2c2c2;
+    background-color: #c2c2c2;
+  }
+
+  .mat-mdc-card-content {
+    padding: 10px 16px;
+    flex-grow: 1;
+  }
+
+  @media (max-width: 768px) {
+    .item {
+      min-width: 100% !important;
+      flex: none;
+    }
+  }
+  
+  @media (max-width: 480px) {
+    .item {
+      min-width: 100% !important;
+      max-width: 100%;
+      min-height: 100px;
+      max-height: 150px;
+    }
+  }
+}

--- a/src/app/examples/defer-block/defer-block.component.ts
+++ b/src/app/examples/defer-block/defer-block.component.ts
@@ -1,0 +1,18 @@
+import { Component, signal, WritableSignal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatGridListModule } from '@angular/material/grid-list';
+import { MatIconModule } from '@angular/material/icon';
+import { ExampleModel } from '../../shared/models/example.model';
+import { DEFER_BLOCK_EXAMPLES } from './example-data/defer-block-examples';
+
+@Component({
+    selector: 'app-defer-block',
+    imports: [CommonModule, RouterModule, MatCardModule, MatGridListModule, MatIconModule],
+    templateUrl: './defer-block.component.html',
+    styleUrl: './defer-block.component.scss'
+})
+export default class DeferBlockComponent {
+    deferBlockExamples: WritableSignal<ExampleModel[]> = signal(DEFER_BLOCK_EXAMPLES);
+}

--- a/src/app/examples/defer-block/defer-example1/defer-example1.component.html
+++ b/src/app/examples/defer-block/defer-example1/defer-example1.component.html
@@ -1,0 +1,40 @@
+<mat-tab-group mat-stretch-tabs>
+  <mat-tab label="Demo">
+    <div class="content-area">
+      <h2>Example 1 - Basic Defer on Idle</h2>
+      <p>This example demonstrates a defer block that loads content when the browser becomes idle.</p>
+      
+      <div class="demo-section">
+        <h3>Immediately Loaded Content</h3>
+        <mat-card>
+          <mat-card-content>
+            This content loads immediately when the component is rendered.
+          </mat-card-content>
+        </mat-card>
+        
+        <h3>Deferred Content (loads on idle)</h3>
+        @defer (on idle) {
+          <mat-card>
+            <mat-card-content>
+              <h4>🎉 This content was loaded when the browser became idle!</h4>
+              <p>This demonstrates the basic defer block functionality. The content inside this card was not loaded initially but only when the browser had idle time.</p>
+              <p>Defer blocks help improve initial page load performance by postponing non-critical content.</p>
+            </mat-card-content>
+          </mat-card>
+        } @placeholder {
+          <mat-card>
+            <mat-card-content>
+              <p>⏳ Loading deferred content when browser is idle...</p>
+            </mat-card-content>
+          </mat-card>
+        }
+      </div>
+    </div>
+  </mat-tab>
+  <mat-tab label="HTML">
+    <markdown clipboard [src]="'assets/examples/defer-block/defer-example1/defer-example1-md.component.html'"></markdown>
+  </mat-tab>
+  <mat-tab label="TS">
+    <markdown clipboard [src]="'assets/examples/defer-block/defer-example1/defer-example1.component.ts'"></markdown>
+  </mat-tab>
+</mat-tab-group>

--- a/src/app/examples/defer-block/defer-example1/defer-example1.component.scss
+++ b/src/app/examples/defer-block/defer-example1/defer-example1.component.scss
@@ -1,0 +1,22 @@
+.content-area {
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.demo-section {
+  margin-top: 2rem;
+  
+  h3 {
+    margin: 2rem 0 1rem 0;
+    color: #1976d2;
+  }
+  
+  mat-card {
+    margin-bottom: 1rem;
+    
+    mat-card-content {
+      padding: 1.5rem;
+    }
+  }
+}

--- a/src/app/examples/defer-block/defer-example1/defer-example1.component.spec.ts
+++ b/src/app/examples/defer-block/defer-example1/defer-example1.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import DeferExample1Component from './defer-example1.component';
+
+describe('DeferExample1Component', () => {
+  let component: DeferExample1Component;
+  let fixture: ComponentFixture<DeferExample1Component>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeferExample1Component]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DeferExample1Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/examples/defer-block/defer-example1/defer-example1.component.ts
+++ b/src/app/examples/defer-block/defer-example1/defer-example1.component.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MarkdownComponent } from 'ngx-markdown';
+
+@Component({
+    selector: 'app-defer-example1',
+    imports: [CommonModule, MatButtonModule, MatCardModule, MatTabsModule, MarkdownComponent],
+    templateUrl: './defer-example1.component.html',
+    styleUrl: './defer-example1.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export default class DeferExample1Component {
+  
+}

--- a/src/app/examples/defer-block/defer-example2/defer-example2.component.html
+++ b/src/app/examples/defer-block/defer-example2/defer-example2.component.html
@@ -1,0 +1,51 @@
+<mat-tab-group mat-stretch-tabs>
+  <mat-tab label="Demo">
+    <div class="content-area">
+      <h2>Example 2 - Defer on Interaction</h2>
+      <p>This example demonstrates a defer block that loads content when the user interacts with a trigger element.</p>
+      
+      <div class="demo-section">
+        <h3>Interactive Trigger</h3>
+        <button mat-raised-button color="primary" #triggerBtn (click)="onButtonClick()">
+          Click me to load deferred content! (Clicked: {{ clickCount() }} times)
+        </button>
+        
+        <div class="deferred-content">
+          @defer (on interaction(triggerBtn)) {
+            <mat-card>
+              <mat-card-content>
+                <h4>🎯 Content loaded after interaction!</h4>
+                <p>This content was deferred and only loaded when you clicked the button above.</p>
+                <p>The defer block listened for an interaction event on the trigger button.</p>
+                <p>Current click count: {{ clickCount() }}</p>
+                <ul>
+                  <li>✅ Reduces initial bundle size</li>
+                  <li>✅ Improves Time to Interactive (TTI)</li>
+                  <li>✅ Loads content only when needed</li>
+                </ul>
+              </mat-card-content>
+            </mat-card>
+          } @placeholder {
+            <mat-card class="placeholder">
+              <mat-card-content>
+                <p>👆 Click the button above to load the deferred content</p>
+              </mat-card-content>
+            </mat-card>
+          } @loading (minimum 500ms) {
+            <mat-card class="loading">
+              <mat-card-content>
+                <p>🔄 Loading content...</p>
+              </mat-card-content>
+            </mat-card>
+          }
+        </div>
+      </div>
+    </div>
+  </mat-tab>
+  <mat-tab label="HTML">
+    <markdown clipboard [src]="'assets/examples/defer-block/defer-example2/defer-example2-md.component.html'"></markdown>
+  </mat-tab>
+  <mat-tab label="TS">
+    <markdown clipboard [src]="'assets/examples/defer-block/defer-example2/defer-example2.component.ts'"></markdown>
+  </mat-tab>
+</mat-tab-group>

--- a/src/app/examples/defer-block/defer-example2/defer-example2.component.scss
+++ b/src/app/examples/defer-block/defer-example2/defer-example2.component.scss
@@ -1,0 +1,49 @@
+.content-area {
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.demo-section {
+  margin-top: 2rem;
+  
+  h3 {
+    margin: 2rem 0 1rem 0;
+    color: #1976d2;
+  }
+}
+
+.deferred-content {
+  margin-top: 2rem;
+  
+  mat-card {
+    margin-top: 1rem;
+    
+    &.placeholder {
+      background-color: #f5f5f5;
+      border: 2px dashed #ccc;
+    }
+    
+    &.loading {
+      background-color: #e3f2fd;
+      border: 2px solid #2196f3;
+      
+      mat-card-content {
+        text-align: center;
+        font-style: italic;
+      }
+    }
+    
+    mat-card-content {
+      padding: 1.5rem;
+      
+      ul {
+        margin-top: 1rem;
+        
+        li {
+          margin-bottom: 0.5rem;
+        }
+      }
+    }
+  }
+}

--- a/src/app/examples/defer-block/defer-example2/defer-example2.component.spec.ts
+++ b/src/app/examples/defer-block/defer-example2/defer-example2.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import DeferExample2Component from './defer-example2.component';
+
+describe('DeferExample2Component', () => {
+  let component: DeferExample2Component;
+  let fixture: ComponentFixture<DeferExample2Component>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeferExample2Component]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DeferExample2Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/examples/defer-block/defer-example2/defer-example2.component.ts
+++ b/src/app/examples/defer-block/defer-example2/defer-example2.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MarkdownComponent } from 'ngx-markdown';
+
+@Component({
+    selector: 'app-defer-example2',
+    imports: [CommonModule, MatButtonModule, MatCardModule, MatTabsModule, MarkdownComponent],
+    templateUrl: './defer-example2.component.html',
+    styleUrl: './defer-example2.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export default class DeferExample2Component {
+  clickCount = signal(0);
+  
+  onButtonClick() {
+    this.clickCount.update(count => count + 1);
+  }
+}

--- a/src/app/examples/defer-block/defer-example3/defer-example3.component.html
+++ b/src/app/examples/defer-block/defer-example3/defer-example3.component.html
@@ -1,0 +1,88 @@
+<mat-tab-group mat-stretch-tabs>
+  <mat-tab label="Demo">
+    <div class="content-area">
+      <h2>Example 3 - Defer on Viewport</h2>
+      <p>This example demonstrates a defer block that loads content when it enters the viewport (intersection observer).</p>
+      
+      <div class="demo-section">
+        <h3>Scroll down to trigger viewport-based loading</h3>
+        
+        <div class="spacer">
+          <mat-card>
+            <mat-card-content>
+              <p>📄 This is regular content that loads immediately.</p>
+              <p>Keep scrolling down to see the deferred content load when it enters the viewport...</p>
+            </mat-card-content>
+          </mat-card>
+        </div>
+        
+        <div class="spacer">
+          <mat-card>
+            <mat-card-content>
+              <p>📄 More regular content...</p>
+              <p>The deferred content below will only load when you scroll it into view.</p>
+            </mat-card-content>
+          </mat-card>
+        </div>
+        
+        <div class="spacer">
+          <mat-card>
+            <mat-card-content>
+              <p>📄 Keep scrolling...</p>
+              <p>Almost there! The deferred content is just below.</p>
+            </mat-card-content>
+          </mat-card>
+        </div>
+        
+        <div class="viewport-trigger" #viewportTrigger>
+          @defer (on viewport(viewportTrigger)) {
+            <mat-card class="deferred-card">
+              <mat-card-content>
+                <h4>👁️ Content loaded when entering viewport!</h4>
+                <p>This content was deferred and only loaded when it entered the viewport.</p>
+                <p>This pattern is perfect for:</p>
+                <ul>
+                  <li>🖼️ Image galleries</li>
+                  <li>📊 Charts and data visualizations</li>
+                  <li>🎬 Video players</li>
+                  <li>📱 Social media feeds</li>
+                  <li>🛒 Product recommendations</li>
+                </ul>
+                <p>It helps improve initial page load performance by only loading content when it's actually needed!</p>
+              </mat-card-content>
+            </mat-card>
+          } @placeholder {
+            <mat-card class="placeholder">
+              <mat-card-content>
+                <p>👀 Placeholder - Content will load when this area enters the viewport</p>
+                <div class="placeholder-box"></div>
+              </mat-card-content>
+            </mat-card>
+          } @loading (minimum 300ms) {
+            <mat-card class="loading">
+              <mat-card-content>
+                <p>🔄 Loading viewport content...</p>
+                <div class="loading-spinner"></div>
+              </mat-card-content>
+            </mat-card>
+          }
+        </div>
+        
+        <div class="spacer">
+          <mat-card>
+            <mat-card-content>
+              <p>📄 Content after the deferred section.</p>
+              <p>Great! You've seen how viewport-based defer blocks work.</p>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </div>
+    </div>
+  </mat-tab>
+  <mat-tab label="HTML">
+    <markdown clipboard [src]="'assets/examples/defer-block/defer-example3/defer-example3-md.component.html'"></markdown>
+  </mat-tab>
+  <mat-tab label="TS">
+    <markdown clipboard [src]="'assets/examples/defer-block/defer-example3/defer-example3.component.ts'"></markdown>
+  </mat-tab>
+</mat-tab-group>

--- a/src/app/examples/defer-block/defer-example3/defer-example3.component.scss
+++ b/src/app/examples/defer-block/defer-example3/defer-example3.component.scss
@@ -1,0 +1,94 @@
+.content-area {
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.demo-section {
+  margin-top: 2rem;
+  
+  h3 {
+    margin: 2rem 0 1rem 0;
+    color: #1976d2;
+  }
+}
+
+.spacer {
+  margin: 3rem 0;
+  
+  mat-card {
+    mat-card-content {
+      padding: 2rem;
+    }
+  }
+}
+
+.viewport-trigger {
+  margin: 2rem 0;
+  
+  mat-card {
+    &.deferred-card {
+      background: linear-gradient(135deg, #e8f5e8 0%, #f0f8ff 100%);
+      border: 2px solid #4caf50;
+    }
+    
+    &.placeholder {
+      background-color: #f5f5f5;
+      border: 2px dashed #ccc;
+      min-height: 200px;
+      
+      .placeholder-box {
+        width: 100%;
+        height: 100px;
+        background: repeating-linear-gradient(
+          45deg,
+          #e0e0e0,
+          #e0e0e0 10px,
+          #f5f5f5 10px,
+          #f5f5f5 20px
+        );
+        margin-top: 1rem;
+        border-radius: 4px;
+      }
+    }
+    
+    &.loading {
+      background-color: #e3f2fd;
+      border: 2px solid #2196f3;
+      min-height: 150px;
+      
+      mat-card-content {
+        text-align: center;
+        font-style: italic;
+        
+        .loading-spinner {
+          width: 40px;
+          height: 40px;
+          border: 4px solid #e3f2fd;
+          border-top: 4px solid #2196f3;
+          border-radius: 50%;
+          animation: spin 1s linear infinite;
+          margin: 1rem auto;
+        }
+      }
+    }
+    
+    mat-card-content {
+      padding: 1.5rem;
+      
+      ul {
+        margin-top: 1rem;
+        text-align: left;
+        
+        li {
+          margin-bottom: 0.5rem;
+        }
+      }
+    }
+  }
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/src/app/examples/defer-block/defer-example3/defer-example3.component.spec.ts
+++ b/src/app/examples/defer-block/defer-example3/defer-example3.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import DeferExample3Component from './defer-example3.component';
+
+describe('DeferExample3Component', () => {
+  let component: DeferExample3Component;
+  let fixture: ComponentFixture<DeferExample3Component>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeferExample3Component]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DeferExample3Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/examples/defer-block/defer-example3/defer-example3.component.ts
+++ b/src/app/examples/defer-block/defer-example3/defer-example3.component.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MarkdownComponent } from 'ngx-markdown';
+
+@Component({
+    selector: 'app-defer-example3',
+    imports: [CommonModule, MatButtonModule, MatCardModule, MatTabsModule, MarkdownComponent],
+    templateUrl: './defer-example3.component.html',
+    styleUrl: './defer-example3.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export default class DeferExample3Component {
+  
+}

--- a/src/app/examples/defer-block/defer-example4/defer-example4.component.html
+++ b/src/app/examples/defer-block/defer-example4/defer-example4.component.html
@@ -1,0 +1,94 @@
+<mat-tab-group mat-stretch-tabs>
+  <mat-tab label="Demo">
+    <div class="content-area">
+      <h2>Example 4 - Defer with Timer</h2>
+      <p>This example demonstrates a defer block that loads content after a specific time delay.</p>
+      
+      <div class="demo-section">
+        <div class="timer-section">
+          <mat-card>
+            <mat-card-content>
+              <h3>⏱️ Timer Demo</h3>
+              <p>The deferred content below will load after 3 seconds:</p>
+              @if (countdown() > 0) {
+                <div class="countdown">
+                  <span class="countdown-number">{{ countdown() }}</span>
+                  <span class="countdown-text">seconds remaining...</span>
+                </div>
+              } @else {
+                <div class="countdown">
+                  <span class="countdown-text">✅ Timer completed!</span>
+                </div>
+              }
+            </mat-card-content>
+          </mat-card>
+        </div>
+        
+        <div class="deferred-section">
+          @defer (on timer(3s)) {
+            <mat-card class="deferred-card">
+              <mat-card-content>
+                <h4>⏰ Content loaded after 3 seconds!</h4>
+                <p>This content was deferred and loaded automatically after a 3-second timer.</p>
+                <p>Timer-based defer blocks are useful for:</p>
+                <ul>
+                  <li>🎯 Progressive content loading</li>
+                  <li>📰 News feeds and updates</li>
+                  <li>💡 Tips and hints</li>
+                  <li>📊 Analytics widgets</li>
+                  <li>🔔 Non-critical notifications</li>
+                </ul>
+                <p>This helps balance user experience with performance by loading secondary content after the main content has had time to render.</p>
+                
+                <button mat-raised-button color="primary" (click)="restartDemo()">
+                  🔄 Restart Demo
+                </button>
+              </mat-card-content>
+            </mat-card>
+          } @placeholder {
+            <mat-card class="placeholder">
+              <mat-card-content>
+                <div class="placeholder-content">
+                  <p>⏳ Waiting for timer to complete...</p>
+                  <div class="timer-bars">
+                    <div class="timer-bar" [style.animation-delay]="'0s'"></div>
+                    <div class="timer-bar" [style.animation-delay]="'0.5s'"></div>
+                    <div class="timer-bar" [style.animation-delay]="'1s'"></div>
+                    <div class="timer-bar" [style.animation-delay]="'1.5s'"></div>
+                  </div>
+                </div>
+              </mat-card-content>
+            </mat-card>
+          } @loading (minimum 200ms) {
+            <mat-card class="loading">
+              <mat-card-content>
+                <p>🔄 Loading timed content...</p>
+              </mat-card-content>
+            </mat-card>
+          }
+        </div>
+        
+        <div class="info-section">
+          <mat-card>
+            <mat-card-content>
+              <h4>How Timer Defer Works</h4>
+              <p>The <code>&#64;defer (on timer(3s))</code> block waits for the specified duration before loading the content.</p>
+              <p>You can specify different time units:</p>
+              <ul>
+                <li><code>timer(1s)</code> - 1 second</li>
+                <li><code>timer(500ms)</code> - 500 milliseconds</li>
+                <li><code>timer(2m)</code> - 2 minutes</li>
+              </ul>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </div>
+    </div>
+  </mat-tab>
+  <mat-tab label="HTML">
+    <markdown clipboard [src]="'assets/examples/defer-block/defer-example4/defer-example4-md.component.html'"></markdown>
+  </mat-tab>
+  <mat-tab label="TS">
+    <markdown clipboard [src]="'assets/examples/defer-block/defer-example4/defer-example4.component.ts'"></markdown>
+  </mat-tab>
+</mat-tab-group>

--- a/src/app/examples/defer-block/defer-example4/defer-example4.component.scss
+++ b/src/app/examples/defer-block/defer-example4/defer-example4.component.scss
@@ -1,0 +1,124 @@
+.content-area {
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.demo-section {
+  margin-top: 2rem;
+}
+
+.timer-section {
+  margin-bottom: 2rem;
+  
+  mat-card {
+    background: linear-gradient(135deg, #fff3e0 0%, #fce4ec 100%);
+    border: 2px solid #ff9800;
+    
+    .countdown {
+      text-align: center;
+      margin-top: 1rem;
+      
+      .countdown-number {
+        font-size: 3rem;
+        font-weight: bold;
+        color: #ff9800;
+        display: block;
+        line-height: 1;
+      }
+      
+      .countdown-text {
+        font-size: 1.2rem;
+        color: #666;
+        margin-top: 0.5rem;
+        display: block;
+      }
+    }
+  }
+}
+
+.deferred-section {
+  margin: 2rem 0;
+  
+  mat-card {
+    &.deferred-card {
+      background: linear-gradient(135deg, #e8f5e8 0%, #f0f8ff 100%);
+      border: 2px solid #4caf50;
+    }
+    
+    &.placeholder {
+      background-color: #f5f5f5;
+      border: 2px dashed #ccc;
+      
+      .placeholder-content {
+        text-align: center;
+        
+        .timer-bars {
+          display: flex;
+          justify-content: center;
+          gap: 0.5rem;
+          margin-top: 1rem;
+          
+          .timer-bar {
+            width: 8px;
+            height: 40px;
+            background: linear-gradient(to top, #ff9800, #ffc107);
+            border-radius: 4px;
+            animation: pulse 1.5s ease-in-out infinite;
+          }
+        }
+      }
+    }
+    
+    &.loading {
+      background-color: #e3f2fd;
+      border: 2px solid #2196f3;
+      
+      mat-card-content {
+        text-align: center;
+        font-style: italic;
+      }
+    }
+    
+    mat-card-content {
+      padding: 1.5rem;
+      
+      ul {
+        margin-top: 1rem;
+        text-align: left;
+        
+        li {
+          margin-bottom: 0.5rem;
+        }
+      }
+      
+      code {
+        background-color: #f5f5f5;
+        padding: 0.2rem 0.4rem;
+        border-radius: 3px;
+        font-family: 'Courier New', monospace;
+        font-size: 0.9em;
+      }
+    }
+  }
+}
+
+.info-section {
+  margin-top: 2rem;
+  
+  mat-card {
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
+  }
+}
+
+@keyframes pulse {
+  0%, 100% {
+    transform: scaleY(1);
+    opacity: 0.7;
+  }
+  50% {
+    transform: scaleY(1.5);
+    opacity: 1;
+  }
+}

--- a/src/app/examples/defer-block/defer-example4/defer-example4.component.spec.ts
+++ b/src/app/examples/defer-block/defer-example4/defer-example4.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import DeferExample4Component from './defer-example4.component';
+
+describe('DeferExample4Component', () => {
+  let component: DeferExample4Component;
+  let fixture: ComponentFixture<DeferExample4Component>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeferExample4Component]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DeferExample4Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/examples/defer-block/defer-example4/defer-example4.component.ts
+++ b/src/app/examples/defer-block/defer-example4/defer-example4.component.ts
@@ -1,0 +1,45 @@
+import { ChangeDetectionStrategy, Component, signal, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MarkdownComponent } from 'ngx-markdown';
+
+@Component({
+    selector: 'app-defer-example4',
+    imports: [CommonModule, MatButtonModule, MatCardModule, MatTabsModule, MarkdownComponent],
+    templateUrl: './defer-example4.component.html',
+    styleUrl: './defer-example4.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export default class DeferExample4Component implements OnInit, OnDestroy {
+  countdown = signal(3);
+  private intervalId?: any;
+  
+  ngOnInit() {
+    this.startCountdown();
+  }
+  
+  ngOnDestroy() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+    }
+  }
+  
+  startCountdown() {
+    this.countdown.set(3);
+    this.intervalId = setInterval(() => {
+      const current = this.countdown();
+      if (current > 0) {
+        this.countdown.set(current - 1);
+      } else {
+        clearInterval(this.intervalId);
+      }
+    }, 1000);
+  }
+  
+  restartDemo() {
+    // Reset the page to restart the demo
+    window.location.reload();
+  }
+}

--- a/src/app/examples/defer-block/defer-example5/defer-example5.component.html
+++ b/src/app/examples/defer-block/defer-example5/defer-example5.component.html
@@ -1,0 +1,164 @@
+<mat-tab-group mat-stretch-tabs>
+  <mat-tab label="Demo">
+    <div class="content-area">
+      <h2>Example 5 - Advanced Defer with Multiple Triggers</h2>
+      <p>This example demonstrates defer blocks with multiple triggers and advanced features including when conditions and error handling.</p>
+      
+      <div class="demo-section">
+        <div class="controls-section">
+          <mat-card>
+            <mat-card-content>
+              <h3>🎛️ Control Panel</h3>
+              <div class="button-group">
+                <button mat-raised-button color="primary" #interactionTrigger (click)="triggerManualLoad()">
+                  Trigger Manual Load
+                </button>
+                <button mat-raised-button color="warn" (click)="resetDemo()">
+                  Reset Demo
+                </button>
+              </div>
+              <div class="status-chips">
+                <mat-chip [highlighted]="manualTrigger()">
+                  Manual Trigger: {{ manualTrigger() ? 'Active' : 'Inactive' }}
+                </mat-chip>
+              </div>
+            </mat-card-content>
+          </mat-card>
+        </div>
+        
+        <!-- Defer with multiple triggers -->
+        <div class="multi-trigger-section">
+          <h3>🔄 Multiple Triggers (Interaction OR Timer)</h3>
+          @defer (on interaction(interactionTrigger); on timer(5s)) {
+            <mat-card class="success-card">
+              <mat-card-content>
+                <h4>✅ Content loaded with multiple triggers!</h4>
+                <p>This content loaded because either:</p>
+                <ul>
+                  <li>You clicked the "Trigger Manual Load" button, OR</li>
+                  <li>5 seconds passed since page load</li>
+                </ul>
+                <p>Multiple triggers use the semicolon (;) separator and work with OR logic.</p>
+              </mat-card-content>
+            </mat-card>
+          } @placeholder {
+            <mat-card class="placeholder">
+              <mat-card-content>
+                <p>⏳ Waiting for interaction OR 5-second timer...</p>
+                <div class="progress-indicator">
+                  <div class="progress-bar"></div>
+                </div>
+              </mat-card-content>
+            </mat-card>
+          } @loading (minimum 300ms) {
+            <mat-card class="loading">
+              <mat-card-content>
+                <p>🔄 Loading content...</p>
+              </mat-card-content>
+            </mat-card>
+          }
+        </div>
+        
+        <!-- Defer with when condition -->
+        <div class="conditional-section">
+          <h3>🎯 Conditional Defer (with 'when')</h3>
+          @defer (when manualTrigger()) {
+            <mat-card class="conditional-card">
+              <mat-card-content>
+                <h4>🎯 Conditionally loaded content!</h4>
+                <p>This content only loads when the manual trigger signal becomes true.</p>
+                <p>The 'when' condition provides fine-grained control over when content should load.</p>
+                <p>Current trigger state: <strong>{{ manualTrigger() }}</strong></p>
+              </mat-card-content>
+            </mat-card>
+          } @placeholder {
+            <mat-card class="placeholder">
+              <mat-card-content>
+                <p>🎯 Click "Trigger Manual Load" to see conditional content</p>
+              </mat-card-content>
+            </mat-card>
+          }
+        </div>
+        
+        <!-- Defer with error handling -->
+        <div class="error-section">
+          <h3>⚠️ Defer with Error Handling</h3>
+          @defer (on timer(2s)) {
+            <mat-card class="success-card">
+              <mat-card-content>
+                <h4>📦 Heavy Component Loaded</h4>
+                <p>This represents a complex component that might fail to load.</p>
+                <p>In real scenarios, this could be:</p>
+                <ul>
+                  <li>📊 Complex data visualization</li>
+                  <li>🎮 Game components</li>
+                  <li>🗺️ Map widgets</li>
+                  <li>📹 Video players</li>
+                </ul>
+              </mat-card-content>
+            </mat-card>
+          } @placeholder {
+            <mat-card class="placeholder">
+              <mat-card-content>
+                <p>⏳ Loading heavy component in 2 seconds...</p>
+              </mat-card-content>
+            </mat-card>
+          } @loading (minimum 500ms) {
+            <mat-card class="loading">
+              <mat-card-content>
+                <p>📦 Loading heavy component...</p>
+              </mat-card-content>
+            </mat-card>
+          } @error {
+            <mat-card class="error-card">
+              <mat-card-content>
+                <h4>❌ Failed to load component</h4>
+                <p>The component failed to load. This could happen due to:</p>
+                <ul>
+                  <li>Network issues</li>
+                  <li>Component errors</li>
+                  <li>Missing dependencies</li>
+                </ul>
+                <button mat-raised-button color="primary" (click)="resetDemo()">
+                  Retry Loading
+                </button>
+              </mat-card-content>
+            </mat-card>
+          }
+        </div>
+        
+        <div class="info-section">
+          <mat-card>
+            <mat-card-content>
+              <h4>🎓 Advanced Defer Features</h4>
+              <div class="feature-grid">
+                <div class="feature">
+                  <h5>Multiple Triggers</h5>
+                  <p>Use semicolons to separate multiple triggers: <code>on interaction(btn); on timer(5s)</code></p>
+                </div>
+                <div class="feature">
+                  <h5>When Conditions</h5>
+                  <p>Use reactive conditions: <code>when mySignal()</code></p>
+                </div>
+                <div class="feature">
+                  <h5>Error Handling</h5>
+                  <p>Handle loading failures with <code>&#64;error</code> blocks</p>
+                </div>
+                <div class="feature">
+                  <h5>Loading States</h5>
+                  <p>Control loading duration with <code>minimum</code> option</p>
+                </div>
+              </div>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      </div>
+    </div>
+  </mat-tab>
+  <mat-tab label="HTML">
+    <markdown clipboard [src]="'assets/examples/defer-block/defer-example5/defer-example5-md.component.html'"></markdown>
+  </mat-tab>
+  <mat-tab label="TS">
+    <markdown clipboard [src]="'assets/examples/defer-block/defer-example5/defer-example5.component.ts'"></markdown>
+  </mat-tab>
+</mat-tab-group>

--- a/src/app/examples/defer-block/defer-example5/defer-example5.component.scss
+++ b/src/app/examples/defer-block/defer-example5/defer-example5.component.scss
@@ -1,0 +1,155 @@
+.content-area {
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.demo-section {
+  margin-top: 2rem;
+  
+  h3 {
+    margin: 2rem 0 1rem 0;
+    color: #1976d2;
+  }
+}
+
+.controls-section {
+  margin-bottom: 3rem;
+  
+  mat-card {
+    background: linear-gradient(135deg, #e8eaf6 0%, #f3e5f5 100%);
+    border: 2px solid #673ab7;
+    
+    .button-group {
+      display: flex;
+      gap: 1rem;
+      margin-bottom: 1rem;
+      flex-wrap: wrap;
+    }
+    
+    .status-chips {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+  }
+}
+
+.multi-trigger-section,
+.conditional-section,
+.error-section {
+  margin: 3rem 0;
+  
+  mat-card {
+    &.success-card {
+      background: linear-gradient(135deg, #e8f5e8 0%, #f0f8ff 100%);
+      border: 2px solid #4caf50;
+    }
+    
+    &.conditional-card {
+      background: linear-gradient(135deg, #fff3e0 0%, #fce4ec 100%);
+      border: 2px solid #ff9800;
+    }
+    
+    &.error-card {
+      background: linear-gradient(135deg, #ffebee 0%, #fce4ec 100%);
+      border: 2px solid #f44336;
+    }
+    
+    &.placeholder {
+      background-color: #f5f5f5;
+      border: 2px dashed #ccc;
+      
+      .progress-indicator {
+        margin-top: 1rem;
+        width: 100%;
+        height: 4px;
+        background-color: #e0e0e0;
+        border-radius: 2px;
+        overflow: hidden;
+        
+        .progress-bar {
+          height: 100%;
+          background: linear-gradient(90deg, #2196f3, #21cbf3);
+          animation: progress 5s linear infinite;
+          width: 0%;
+        }
+      }
+    }
+    
+    &.loading {
+      background-color: #e3f2fd;
+      border: 2px solid #2196f3;
+      
+      mat-card-content {
+        text-align: center;
+        font-style: italic;
+      }
+    }
+    
+    mat-card-content {
+      padding: 1.5rem;
+      
+      ul {
+        margin-top: 1rem;
+        text-align: left;
+        
+        li {
+          margin-bottom: 0.5rem;
+        }
+      }
+      
+      code {
+        background-color: #f5f5f5;
+        padding: 0.2rem 0.4rem;
+        border-radius: 3px;
+        font-family: 'Courier New', monospace;
+        font-size: 0.9em;
+      }
+    }
+  }
+}
+
+.info-section {
+  margin-top: 3rem;
+  
+  mat-card {
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
+    
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 1.5rem;
+      margin-top: 1rem;
+      
+      .feature {
+        padding: 1rem;
+        background-color: white;
+        border-radius: 8px;
+        border: 1px solid #e0e0e0;
+        
+        h5 {
+          margin: 0 0 0.5rem 0;
+          color: #1976d2;
+          font-weight: 600;
+        }
+        
+        p {
+          margin: 0;
+          font-size: 0.9rem;
+          line-height: 1.4;
+        }
+      }
+    }
+  }
+}
+
+@keyframes progress {
+  0% {
+    width: 0%;
+  }
+  100% {
+    width: 100%;
+  }
+}

--- a/src/app/examples/defer-block/defer-example5/defer-example5.component.spec.ts
+++ b/src/app/examples/defer-block/defer-example5/defer-example5.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import DeferExample5Component from './defer-example5.component';
+
+describe('DeferExample5Component', () => {
+  let component: DeferExample5Component;
+  let fixture: ComponentFixture<DeferExample5Component>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeferExample5Component]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DeferExample5Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/examples/defer-block/defer-example5/defer-example5.component.ts
+++ b/src/app/examples/defer-block/defer-example5/defer-example5.component.ts
@@ -1,0 +1,30 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatChipsModule } from '@angular/material/chips';
+import { MarkdownComponent } from 'ngx-markdown';
+
+@Component({
+    selector: 'app-defer-example5',
+    imports: [CommonModule, MatButtonModule, MatCardModule, MatTabsModule, MatChipsModule, MarkdownComponent],
+    templateUrl: './defer-example5.component.html',
+    styleUrl: './defer-example5.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export default class DeferExample5Component {
+  manualTrigger = signal(false);
+  
+  triggerManualLoad() {
+    this.manualTrigger.set(true);
+  }
+  
+  resetDemo() {
+    this.manualTrigger.set(false);
+    // Small delay to allow the reset to take effect
+    setTimeout(() => {
+      window.location.reload();
+    }, 100);
+  }
+}

--- a/src/app/examples/defer-block/example-data/defer-block-examples.ts
+++ b/src/app/examples/defer-block/example-data/defer-block-examples.ts
@@ -1,0 +1,29 @@
+import { ExampleModel } from '../../../shared/models/example.model';
+
+export const DEFER_BLOCK_EXAMPLES: ExampleModel[] = [
+  {
+    title: 'Example 1',
+    content: 'Basic Defer on Idle - Loads content when browser becomes idle',
+    routerLink: '/defer-block/defer-example1',
+  },
+  {
+    title: 'Example 2',
+    content: 'Defer on Interaction - Triggers loading when user interacts with element',
+    routerLink: '/defer-block/defer-example2',
+  },
+  {
+    title: 'Example 3',
+    content: 'Defer on Viewport - Loads content when it enters the viewport',
+    routerLink: '/defer-block/defer-example3',
+  },
+  {
+    title: 'Example 4',
+    content: 'Defer with Timer - Loads content after specified time delay',
+    routerLink: '/defer-block/defer-example4',
+  },
+  {
+    title: 'Example 5',
+    content: 'Advanced Defer - Multiple triggers, conditions, and error handling',
+    routerLink: '/defer-block/defer-example5',
+  },
+];

--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -11,6 +11,10 @@
     Resource API
   </button>
 
+  <button mat-button [routerLink]="['/defer-block']" routerLinkActive="active">
+    Defer Block
+  </button>
+
   <span class="menu-spacer"></span>
 
   <a

--- a/src/assets/examples/defer-block/defer-example1/defer-example1-md.component.html
+++ b/src/assets/examples/defer-block/defer-example1/defer-example1-md.component.html
@@ -1,0 +1,30 @@
+<div class="content-area">
+  <h2>Example 1 - Basic Defer on Idle</h2>
+  <p>This example demonstrates a defer block that loads content when the browser becomes idle.</p>
+  
+  <div class="demo-section">
+    <h3>Immediately Loaded Content</h3>
+    <mat-card>
+      <mat-card-content>
+        This content loads immediately when the component is rendered.
+      </mat-card-content>
+    </mat-card>
+    
+    <h3>Deferred Content (loads on idle)</h3>
+    @defer (on idle) {
+      <mat-card>
+        <mat-card-content>
+          <h4>🎉 This content was loaded when the browser became idle!</h4>
+          <p>This demonstrates the basic defer block functionality. The content inside this card was not loaded initially but only when the browser had idle time.</p>
+          <p>Defer blocks help improve initial page load performance by postponing non-critical content.</p>
+        </mat-card-content>
+      </mat-card>
+    } @placeholder {
+      <mat-card>
+        <mat-card-content>
+          <p>⏳ Loading deferred content when browser is idle...</p>
+        </mat-card-content>
+      </mat-card>
+    }
+  </div>
+</div>

--- a/src/assets/examples/defer-block/defer-example1/defer-example1.component.ts
+++ b/src/assets/examples/defer-block/defer-example1/defer-example1.component.ts
@@ -1,0 +1,16 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
+
+@Component({
+    selector: 'app-defer-example1',
+    standalone: true,
+    imports: [CommonModule, MatButtonModule, MatCardModule, MatTabsModule],
+    templateUrl: './defer-example1-md.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export default class DeferExample1Component {
+  
+}

--- a/src/assets/examples/defer-block/defer-example2/defer-example2-md.component.html
+++ b/src/assets/examples/defer-block/defer-example2/defer-example2-md.component.html
@@ -1,0 +1,41 @@
+<div class="content-area">
+  <h2>Example 2 - Defer on Interaction</h2>
+  <p>This example demonstrates a defer block that loads content when the user interacts with a trigger element.</p>
+  
+  <div class="demo-section">
+    <h3>Interactive Trigger</h3>
+    <button mat-raised-button color="primary" #triggerBtn (click)="onButtonClick()">
+      Click me to load deferred content! (Clicked: {{ clickCount() }} times)
+    </button>
+    
+    <div class="deferred-content">
+      @defer (on interaction(triggerBtn)) {
+        <mat-card>
+          <mat-card-content>
+            <h4>🎯 Content loaded after interaction!</h4>
+            <p>This content was deferred and only loaded when you clicked the button above.</p>
+            <p>The defer block listened for an interaction event on the trigger button.</p>
+            <p>Current click count: {{ clickCount() }}</p>
+            <ul>
+              <li>✅ Reduces initial bundle size</li>
+              <li>✅ Improves Time to Interactive (TTI)</li>
+              <li>✅ Loads content only when needed</li>
+            </ul>
+          </mat-card-content>
+        </mat-card>
+      } @placeholder {
+        <mat-card class="placeholder">
+          <mat-card-content>
+            <p>👆 Click the button above to load the deferred content</p>
+          </mat-card-content>
+        </mat-card>
+      } @loading (minimum 500ms) {
+        <mat-card class="loading">
+          <mat-card-content>
+            <p>🔄 Loading content...</p>
+          </mat-card-content>
+        </mat-card>
+      }
+    </div>
+  </div>
+</div>

--- a/src/assets/examples/defer-block/defer-example2/defer-example2.component.ts
+++ b/src/assets/examples/defer-block/defer-example2/defer-example2.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
+
+@Component({
+    selector: 'app-defer-example2',
+    standalone: true,
+    imports: [CommonModule, MatButtonModule, MatCardModule, MatTabsModule],
+    templateUrl: './defer-example2-md.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export default class DeferExample2Component {
+  clickCount = signal(0);
+  
+  onButtonClick() {
+    this.clickCount.update(count => count + 1);
+  }
+}

--- a/src/assets/examples/defer-block/defer-example3/defer-example3-md.component.html
+++ b/src/assets/examples/defer-block/defer-example3/defer-example3-md.component.html
@@ -1,0 +1,27 @@
+<h2>Example 3 - Defer on Viewport</h2>
+      <p>This example demonstrates a defer block that loads content when it enters the viewport.</p>
+      
+      <div class="spacer">
+        <mat-card>
+          <mat-card-content>
+            <p>📄 Keep scrolling down to see the deferred content load when it enters the viewport...</p>
+          </mat-card-content>
+        </mat-card>
+      </div>
+      
+      <div class="viewport-trigger" #viewportTrigger>
+        @defer (on viewport(viewportTrigger)) {
+          <mat-card class="deferred-card">
+            <mat-card-content>
+              <h4>👁️ Content loaded when entering viewport!</h4>
+              <p>This content was deferred and only loaded when it entered the viewport.</p>
+            </mat-card-content>
+          </mat-card>
+        } @placeholder {
+          <mat-card class="placeholder">
+            <mat-card-content>
+              <p>👀 Placeholder - Content will load when this area enters the viewport</p>
+            </mat-card-content>
+          </mat-card>
+        }
+      </div>

--- a/src/assets/examples/defer-block/defer-example3/defer-example3.component.ts
+++ b/src/assets/examples/defer-block/defer-example3/defer-example3.component.ts
@@ -1,0 +1,16 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
+
+@Component({
+    selector: 'app-defer-example3',
+    standalone: true,
+    imports: [CommonModule, MatButtonModule, MatCardModule, MatTabsModule],
+    templateUrl: './defer-example3-md.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export default class DeferExample3Component {
+  
+}

--- a/src/assets/examples/defer-block/defer-example4/defer-example4-md.component.html
+++ b/src/assets/examples/defer-block/defer-example4/defer-example4-md.component.html
@@ -1,0 +1,41 @@
+<h2>Example 4 - Defer with Timer</h2>
+      <p>This example demonstrates a defer block that loads content after a specific time delay.</p>
+      
+      <div class="timer-section">
+        <mat-card>
+          <mat-card-content>
+            <h3>⏱️ Timer Demo</h3>
+            <p>The deferred content below will load after 3 seconds:</p>
+            @if (countdown() > 0) {
+              <div class="countdown">
+                <span class="countdown-number">{{ countdown() }}</span>
+                <span class="countdown-text">seconds remaining...</span>
+              </div>
+            } @else {
+              <div class="countdown">
+                <span class="countdown-text">✅ Timer completed!</span>
+              </div>
+            }
+          </mat-card-content>
+        </mat-card>
+      </div>
+      
+      <div class="deferred-section">
+        @defer (on timer(3s)) {
+          <mat-card class="deferred-card">
+            <mat-card-content>
+              <h4>⏰ Content loaded after 3 seconds!</h4>
+              <p>This content was deferred and loaded automatically after a 3-second timer.</p>
+              <button mat-raised-button color="primary" (click)="restartDemo()">
+                🔄 Restart Demo
+              </button>
+            </mat-card-content>
+          </mat-card>
+        } @placeholder {
+          <mat-card class="placeholder">
+            <mat-card-content>
+              <p>⏳ Waiting for timer to complete...</p>
+            </mat-card-content>
+          </mat-card>
+        }
+      </div>

--- a/src/assets/examples/defer-block/defer-example4/defer-example4.component.ts
+++ b/src/assets/examples/defer-block/defer-example4/defer-example4.component.ts
@@ -1,0 +1,43 @@
+import { ChangeDetectionStrategy, Component, signal, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
+
+@Component({
+    selector: 'app-defer-example4',
+    standalone: true,
+    imports: [CommonModule, MatButtonModule, MatCardModule, MatTabsModule],
+    templateUrl: './defer-example4-md.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export default class DeferExample4Component implements OnInit, OnDestroy {
+  countdown = signal(3);
+  private intervalId?: any;
+  
+  ngOnInit() {
+    this.startCountdown();
+  }
+  
+  ngOnDestroy() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+    }
+  }
+  
+  startCountdown() {
+    this.countdown.set(3);
+    this.intervalId = setInterval(() => {
+      const current = this.countdown();
+      if (current > 0) {
+        this.countdown.set(current - 1);
+      } else {
+        clearInterval(this.intervalId);
+      }
+    }, 1000);
+  }
+  
+  restartDemo() {
+    window.location.reload();
+  }
+}

--- a/src/assets/examples/defer-block/defer-example5/defer-example5-md.component.html
+++ b/src/assets/examples/defer-block/defer-example5/defer-example5-md.component.html
@@ -1,0 +1,56 @@
+
+      <h2>Example 5 - Advanced Defer with Multiple Triggers</h2>
+      <p>This example demonstrates defer blocks with multiple triggers and advanced features.</p>
+      
+      <div class="controls-section">
+        <mat-card>
+          <mat-card-content>
+            <h3>🎛️ Control Panel</h3>
+            <button mat-raised-button color="primary" #interactionTrigger (click)="triggerManualLoad()">
+              Trigger Manual Load
+            </button>
+            <mat-chip [highlighted]="manualTrigger()">
+              Manual Trigger: {{ manualTrigger() ? 'Active' : 'Inactive' }}
+            </mat-chip>
+          </mat-card-content>
+        </mat-card>
+      </div>
+      
+      <!-- Defer with multiple triggers -->
+      <div class="multi-trigger-section">
+        <h3>🔄 Multiple Triggers (Interaction OR Timer)</h3>
+        @defer (on interaction(interactionTrigger); on timer(5s)) {
+          <mat-card class="success-card">
+            <mat-card-content>
+              <h4>✅ Content loaded with multiple triggers!</h4>
+              <p>This content loaded because either you clicked the button OR 5 seconds passed.</p>
+            </mat-card-content>
+          </mat-card>
+        } @placeholder {
+          <mat-card class="placeholder">
+            <mat-card-content>
+              <p>⏳ Waiting for interaction OR 5-second timer...</p>
+            </mat-card-content>
+          </mat-card>
+        }
+      </div>
+      
+      <!-- Defer with when condition -->
+      <div class="conditional-section">
+        <h3>🎯 Conditional Defer (When Signal)</h3>
+        @defer (when manualTrigger()) {
+          <mat-card class="conditional-card">
+            <mat-card-content>
+              <h4>🎯 Content loaded when condition is true!</h4>
+              <p>This defer block uses the when condition with a signal.</p>
+            </mat-card-content>
+          </mat-card>
+        } @placeholder {
+          <mat-card class="placeholder">
+            <mat-card-content>
+              <p>⏳ Waiting for manual trigger signal to become true...</p>
+            </mat-card-content>
+          </mat-card>
+        }
+      </div>
+    

--- a/src/assets/examples/defer-block/defer-example5/defer-example5.component.ts
+++ b/src/assets/examples/defer-block/defer-example5/defer-example5.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatChipsModule } from '@angular/material/chips';
+
+@Component({
+    selector: 'app-defer-example5',
+    standalone: true,
+    imports: [CommonModule, MatButtonModule, MatCardModule, MatTabsModule, MatChipsModule],
+    templateUrl: './defer-example5-md.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export default class DeferExample5Component {
+  manualTrigger = signal(false);
+  
+  triggerManualLoad() {
+    this.manualTrigger.set(true);
+  }
+}


### PR DESCRIPTION
- Implemented Example 3: Defer on Viewport, loading content when it enters the viewport.
- Implemented Example 4: Defer with Timer, loading content after a specified time delay.
- Implemented Example 5: Advanced Defer with multiple triggers, conditions, and error handling.
- Added corresponding styles and tests for each example.
- Updated example data to include new examples.